### PR TITLE
Remove use of polyfill

### DIFF
--- a/html.tpl.php
+++ b/html.tpl.php
@@ -16,9 +16,6 @@
 	<!-- For mobile devices - also works on iPad -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
 
-	<!-- OpenLayers requirement for old environments like Internet Explorer and Android 4.x -->
-	<script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL,Array.prototype.includes,String.prototype.padStart,String.prototype.startsWith,String.prototype.endsWith"></script>
-
 	<?php print $styles; ?>
 	<?php print $scripts; ?>
 </head>

--- a/subthemes/aims_ereefs/html.tpl.php
+++ b/subthemes/aims_ereefs/html.tpl.php
@@ -16,9 +16,6 @@
 	<!-- For mobile devices - also works on iPad -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
 
-	<!-- OpenLayers requirement for old environments like Internet Explorer and Android 4.x -->
-	<script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL,Array.prototype.includes,String.prototype.padStart,String.prototype.startsWith,String.prototype.endsWith"></script>
-
 	<!-- Google Analytics v4 for eReefs -->
 	<script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-6SSTNBNHXG"></script>
 	<script type="text/javascript">

--- a/subthemes/amps/html.tpl.php
+++ b/subthemes/amps/html.tpl.php
@@ -16,9 +16,6 @@
 	<!-- For mobile devices - also works on iPad -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
 
-	<!-- OpenLayers requirement for old environments like Internet Explorer and Android 4.x -->
-	<script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL,Array.prototype.includes,String.prototype.padStart,String.prototype.startsWith,String.prototype.endsWith"></script>
-
 	<!-- Google Analytics v4 for AMPSA -->
 	<script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-999XKHTQE4"></script>
 	<script type="text/javascript">

--- a/subthemes/eatlas/html.tpl.php
+++ b/subthemes/eatlas/html.tpl.php
@@ -16,9 +16,6 @@
 	<!-- For mobile devices - also works on iPad -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
 
-	<!-- OpenLayers requirement for old environments like Internet Explorer and Android 4.x -->
-	<script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL,Array.prototype.includes,String.prototype.padStart,String.prototype.startsWith,String.prototype.endsWith"></script>
-
 	<!-- Google Analytics v4 for eAtlas -->
 	<script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-00BMXQPTHG"></script>
 	<script type="text/javascript">

--- a/subthemes/ereefs/html.tpl.php
+++ b/subthemes/ereefs/html.tpl.php
@@ -16,9 +16,6 @@
 	<!-- For mobile devices - also works on iPad -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
 
-	<!-- OpenLayers requirement for old environments like Internet Explorer and Android 4.x -->
-	<script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL,Array.prototype.includes,String.prototype.padStart,String.prototype.startsWith,String.prototype.endsWith"></script>
-
 	<!-- Google Analytics v4 for eReefs -->
 	<script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-6SSTNBNHXG"></script>
 	<script type="text/javascript">

--- a/subthemes/ereefs_aims/html.tpl.php
+++ b/subthemes/ereefs_aims/html.tpl.php
@@ -16,9 +16,6 @@
 	<!-- For mobile devices - also works on iPad -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
 
-	<!-- OpenLayers requirement for old environments like Internet Explorer and Android 4.x -->
-	<script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL,Array.prototype.includes,String.prototype.padStart,String.prototype.startsWith,String.prototype.endsWith"></script>
-
 	<!-- Google Analytics v4 for eReefs -->
 	<script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-6SSTNBNHXG"></script>
 	<script type="text/javascript">

--- a/subthemes/nwa/html.tpl.php
+++ b/subthemes/nwa/html.tpl.php
@@ -16,9 +16,6 @@
 	<!-- For mobile devices - also works on iPad -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
 
-	<!-- OpenLayers requirement for old environments like Internet Explorer and Android 4.x -->
-	<script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL,Array.prototype.includes,String.prototype.padStart,String.prototype.startsWith,String.prototype.endsWith"></script>
-
 	<!-- Google Analytics v4 for eAtlas -->
 	<script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-00BMXQPTHG"></script>
 	<script type="text/javascript">

--- a/subthemes/seltmp/html.tpl.php
+++ b/subthemes/seltmp/html.tpl.php
@@ -16,9 +16,6 @@
 	<!-- For mobile devices - also works on iPad -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
 
-	<!-- OpenLayers requirement for old environments like Internet Explorer and Android 4.x -->
-	<script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL,Array.prototype.includes,String.prototype.padStart,String.prototype.startsWith,String.prototype.endsWith"></script>
-
 	<!-- Google Analytics v4 for eAtlas -->
 	<script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-00BMXQPTHG"></script>
 	<script type="text/javascript">

--- a/subthemes/ts/html.tpl.php
+++ b/subthemes/ts/html.tpl.php
@@ -16,9 +16,6 @@
 	<!-- For mobile devices - also works on iPad -->
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0" />
 
-	<!-- OpenLayers requirement for old environments like Internet Explorer and Android 4.x -->
-	<script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL,Array.prototype.includes,String.prototype.padStart,String.prototype.startsWith,String.prototype.endsWith"></script>
-
 	<!-- Google Analytics v4 for eAtlas -->
 	<script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-00BMXQPTHG"></script>
 	<script type="text/javascript">


### PR DESCRIPTION
Marc determined that polyfill is for supporting browsers older than 2017 and so no longer required.